### PR TITLE
Start APE HTTP server on random port

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "ace_llm_logic"
 version = "0.1.0"
 description = "LLM + ACE + Logic pipeline"
 authors = [{ name = "Your Name", email = "you@example.com" }]
-dependencies = ["openai"]
+dependencies = ["openai", "requests"]
 requires-python = ">=3.8"
 
 [project.scripts]

--- a/python/ace_llm_logic/__main__.py
+++ b/python/ace_llm_logic/__main__.py
@@ -3,15 +3,53 @@ import subprocess
 import argparse
 import time
 import os
+import socket
+from typing import Tuple, Optional
 import openai
+import requests
 
-client = openai.OpenAI()
+
+def start_ape_http_server(ape_script: str = os.path.join("APE", "ape.sh")) -> Tuple[subprocess.Popen, int]:
+    """Start APE in HTTP mode on a random free port."""
+    sock = socket.socket()
+    sock.bind(("", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    proc = subprocess.Popen([
+        ape_script,
+        "-httpserver",
+        "-port",
+        str(port),
+    ], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return proc, port
+
+
+def stop_ape_http_server(proc: subprocess.Popen) -> None:
+    """Terminate the spawned APE process."""
+    if proc and proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+_client: Optional[openai.OpenAI] = None
+
+
+def get_openai_client() -> openai.OpenAI:
+    """Return a cached OpenAI client instance."""
+    global _client
+    if _client is None:
+        _client = openai.OpenAI()
+    return _client
 
 def llm_rewrite_to_ace_english(text):
     prompt = f"""Convert the following sentence into active voice, present tense, declarative form, so it can be parsed by ACE controlled English.
 
 Sentence: "{text}"
 Rewritten:"""
+    client = get_openai_client()
     response = client.chat.completions.create(
         model="gpt-4o",
         messages=[{"role": "user", "content": prompt}],
@@ -19,19 +57,21 @@ Rewritten:"""
     )
     return response.choices[0].message.content.strip()
 
-def parse_with_ace(sentence, ace_path="./ace/bin/ace", grammar_path="./ace/grammars/erg.dat", mock=False):
+def parse_with_ace(sentence: str, endpoint: str, mock: bool = False) -> str:
+    """Send the sentence to an APE HTTP server and return the FOL result."""
     if mock:
-        return "exists x (report(x) ∧ write(alice, x)).\nexists y (data(y) ∧ review(alice, y) ∧ before(write(alice, x), review(alice, y)))."
-    if not os.path.isfile(ace_path):
-        return "ERROR: ACE binary not found and mock mode is disabled."
-    try:
-        result = subprocess.run(
-            [ace_path, "-g", grammar_path, "-1", "-T"],
-            input=sentence.encode("utf-8"),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+        return (
+            "exists x (report(x) ∧ write(alice, x)).\n"
+            "exists y (data(y) ∧ review(alice, y) ∧ before(write(alice, x), review(alice, y)))."
         )
-        return result.stdout.decode("utf-8")
+    try:
+        response = requests.get(
+            f"http://{endpoint}/",
+            params={"text": sentence, "solo": "fol"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.text
     except Exception as e:
         return f"ACE parser error: {e}"
 
@@ -45,6 +85,7 @@ Original ACE-based logic:
 {logic}
 
 Revised logic:"""
+    client = get_openai_client()
     response = client.chat.completions.create(
         model="gpt-4o",
         messages=[{"role": "user", "content": prompt}],
@@ -52,9 +93,21 @@ Revised logic:"""
     )
     return response.choices[0].message.content.strip()
 
-def process_sentence(sentence, mock=False):
+def process_sentence(sentence: str, mock: bool = False, use_http_ape: Optional[str] = None) -> str:
     ace_friendly = llm_rewrite_to_ace_english(sentence)
-    ace_logic = parse_with_ace(ace_friendly, mock=mock)
+    if mock:
+        ace_logic = parse_with_ace(ace_friendly, endpoint="localhost:0", mock=True)
+    else:
+        if use_http_ape:
+            ace_logic = parse_with_ace(ace_friendly, endpoint=use_http_ape)
+        else:
+            proc, port = start_ape_http_server()
+            # Give the server a moment to start
+            time.sleep(1)
+            try:
+                ace_logic = parse_with_ace(ace_friendly, endpoint=f"localhost:{port}")
+            finally:
+                stop_ape_http_server(proc)
     adjusted_logic = llm_adjust_logic(sentence, ace_logic)
     return adjusted_logic
 
@@ -62,6 +115,7 @@ def main():
     parser = argparse.ArgumentParser(description="Convert English to adjusted logic using ACE and OpenAI")
     parser.add_argument('--file', type=str, help='Input file with English text')
     parser.add_argument('--mock', action='store_true', help='Use mock logic output instead of calling ACE')
+    parser.add_argument('--use-http-ape', type=str, help='Connect to existing APE HTTP server host:port')
     args = parser.parse_args()
 
     if args.file:
@@ -77,7 +131,7 @@ def main():
         except EOFError:
             pass
 
-    result = process_sentence(text.strip(), mock=args.mock)
+    result = process_sentence(text.strip(), mock=args.mock, use_http_ape=args.use_http_ape)
     print("\n--- Final Adjusted Logic ---")
     print(result)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 openai
+requests


### PR DESCRIPTION
## Summary
- start APE in HTTP mode on a random port
- add optional `--use-http-ape` CLI flag
- depend on `requests`
- lazily initialize the OpenAI client

## Testing
- `apt update -y`
- `apt install -y swi-prolog-full`
- `pip install -r requirements.txt`
- `pip install -e .`
- `PYTHONPATH=$PWD pytest -q` *(fails: OpenAI API key missing)*

------
https://chatgpt.com/codex/tasks/task_e_687949e273b48325815c752490cb899c