### PR TITLE
Enable live pipeline tests with APE

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ which returns
 pytest tests/
 ```
 
-Tests run in `--mock` mode and do not require ACE.
+Tests require access to an OpenAI API key and will launch a local APE HTTP server.
 
 ---
 

--- a/python/ace_llm_logic/__main__.py
+++ b/python/ace_llm_logic/__main__.py
@@ -7,6 +7,7 @@ import socket
 from typing import Tuple, Optional
 import openai
 import requests
+from urllib.parse import urlencode, quote_plus
 
 
 def start_ape_http_server(ape_script: str = os.path.join("APE", "ape.sh")) -> Tuple[subprocess.Popen, int]:
@@ -65,11 +66,10 @@ def parse_with_ace(sentence: str, endpoint: str, mock: bool = False) -> str:
             "exists y (data(y) ∧ review(alice, y) ∧ before(write(alice, x), review(alice, y)))."
         )
     try:
-        response = requests.get(
-            f"http://{endpoint}/",
-            params={"text": sentence, "solo": "fol"},
-            timeout=30,
-        )
+        # APE's HTTP interface expects spaces encoded as '+' rather than '%20'
+        query = urlencode({"text": sentence, "solo": "fol"}, quote_via=quote_plus)
+        url = f"http://{endpoint}/?{query}"
+        response = requests.get(url, timeout=30)
         response.raise_for_status()
         return response.text
     except Exception as e:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,22 +1,51 @@
 
-from python.ace_llm_logic.__main__ import (
+import pathlib
+import sys
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "python"))
+
+from ace_llm_logic.__main__ import (
     llm_rewrite_to_ace_english,
     llm_adjust_logic,
     process_sentence,
+    start_ape_http_server,
+    stop_ape_http_server,
+    parse_with_ace,
 )
 
-def test_rewrite_mockable():
+import time
+import pytest
+
+
+@pytest.fixture
+def ape_server():
+    """Spin up a temporary APE HTTP server for tests."""
+    repo_root = pathlib.Path(__file__).resolve().parent.parent
+    ape_script = repo_root / "APE" / "ape.sh"
+    proc, port = start_ape_http_server(str(ape_script))
+    time.sleep(3)  # allow server to start
+    endpoint = f"localhost:{port}"
+    try:
+        yield endpoint
+    finally:
+        stop_ape_http_server(proc)
+
+def test_rewrite_live():
     sentence = "The report was written by Alice after she reviewed the data."
     rewritten = llm_rewrite_to_ace_english(sentence)
     assert "writes" in rewritten.lower() or "write" in rewritten.lower()
 
-def test_adjust_logic_mockable():
+def test_adjust_logic_live():
     original = "The report was written by Alice after she reviewed the data."
     dummy_logic = "write(alice, report1). review(alice, data1)."
     adjusted = llm_adjust_logic(original, dummy_logic)
     assert "past" in adjusted.lower() or "passive" in adjusted.lower()
 
-def test_end_to_end_mock():
+def test_end_to_end_real(ape_server):
     sentence = "The report was written by Alice after she reviewed the data."
-    logic = process_sentence(sentence, endpoint="localhost:0", mock=True)
-    assert "write" in logic and "report" in logic
+    logic = process_sentence(sentence, endpoint=ape_server, mock=False)
+    assert "write" in logic.lower() and "report" in logic.lower()
+
+
+def test_bad_sentence_error_known(ape_server):
+    result = parse_with_ace("Blah.", endpoint=ape_server)
+    assert "<messages>" in result and "error" in result.lower()


### PR DESCRIPTION
## Summary
- rely on real OpenAI API and APE server when testing
- update README to reflect new testing requirements
- add fixture that launches the local APE server for tests
- add test for bad sentence parsing errors
- ensure APE request parameters encode spaces with +

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879b0d38d8883259e8d5918ee13dd4c